### PR TITLE
feat(hooks): add useDataFetch hook for fetching data

### DIFF
--- a/src/hooks/useDataFetch.hook.ts
+++ b/src/hooks/useDataFetch.hook.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import type { useDataFetchResponse } from '../type'
+import { useStore } from '@nanostores/react'
+import { isLanguage } from '../store'
+
+export const useDataFetch = <T>(
+  router: string,
+  isLang: boolean = true
+): useDataFetchResponse<T> => {
+  const $lang = useStore(isLanguage)
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const [data, setData] = useState<T>({} as T)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchData = async (): Promise<void> => {
+      try {
+        setIsLoading(true)
+
+        const url: string = isLang
+          ? `/api/content/${router}/${$lang}`
+          : `/api/content/${router}`
+
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`)
+        }
+
+        const jsonData: T = await response.json()
+
+        setData(jsonData)
+        setIsLoading(false)
+        setError(null)
+      } catch (error) {
+        if (error instanceof Error) {
+          setError(error.message)
+        }
+      }
+    }
+
+    void fetchData()
+    return () => {}
+  }, [$lang])
+
+  return [data, isLoading, error]
+}

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -2,6 +2,8 @@ export interface LanguageSharedComponentProps {
   className?: string
 }
 
+export type useDataFetchResponse<T> = [T, boolean, string | null]
+
 /* -------------------------------------------------------------------------- */
 /*                                  Response                                  */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Introduce a new custom hook `useDataFetch` to handle data fetching with loading and error states. The hook supports language-specific API routes and returns a tuple containing the data, loading status, and error message. This improves code reusability and simplifies data fetching logic across the application.