### PR TITLE
Add Vercel adapter to Astro configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,11 +6,15 @@ import tailwindcss from '@tailwindcss/vite'
 
 import react from '@astrojs/react';
 
+import vercel from '@astrojs/vercel';
+
 // https://astro.build/config
 export default defineConfig({
   vite: {
     plugins: [tailwindcss()]
   },
+
   site: 'https://www.jonathanleivag.cl',
-  integrations: [react(), sitemap()]
+  integrations: [react(), sitemap()],
+  adapter: vercel()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/react": "^4.2.4",
         "@astrojs/sitemap": "^3.4.0",
-        "@astrojs/vercel": "8.1.4",
+        "@astrojs/vercel": "^8.1.4",
         "@nanostores/react": "0.8.4",
         "@tailwindcss/vite": "4.0.15",
         "@types/react": "19.0.12",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@astrojs/react": "^4.2.4",
     "@astrojs/sitemap": "^3.4.0",
-    "@astrojs/vercel": "8.1.4",
+    "@astrojs/vercel": "^8.1.4",
     "@nanostores/react": "0.8.4",
     "@tailwindcss/vite": "4.0.15",
     "@types/react": "19.0.12",


### PR DESCRIPTION
Updated the Astro configuration to support deployment using the Vercel adapter. This includes changes to `package.json` and `package-lock.json` for compatibility with `@astrojs/vercel`.