### PR TITLE
Add homepage link to logo component

### DIFF
--- a/src/components/shared/logo.shared.component.tsx
+++ b/src/components/shared/logo.shared.component.tsx
@@ -1,15 +1,17 @@
-import type { FC } from 'react'
-import type { LogoSharedComponentProps } from '../../type'
+import type {FC} from 'react'
+import type {LogoSharedComponentProps} from '../../type'
 
 const LogoSharedComponent: FC<LogoSharedComponentProps> = ({
   className = ''
 }) => {
   return (
-    <img
-      src='https://res.cloudinary.com/dq8fpb695/image/upload/v1662878253/jonathanleivag/logo/ohbxjqje4kelihconfov.png'
-      className={`w-[70px] h-auto ${className}`}
-      alt='Logo of jonathanleivag.cl'
-    />
+    <a href="/">
+      <img
+        src='https://res.cloudinary.com/dq8fpb695/image/upload/v1662878253/jonathanleivag/logo/ohbxjqje4kelihconfov.png'
+        className={`w-[70px] h-auto ${className}`}
+        alt='Logo of jonathanleivag.cl'
+      />
+    </a>
   )
 }
 


### PR DESCRIPTION
Wrapped the logo with an anchor tag linking to the homepage ("/"). This enhances user experience by providing easier navigation back to the main page.