### PR TITLE
Add language selector visibility per environment config

### DIFF
--- a/src/components/shared/navbar.shared.component.tsx
+++ b/src/components/shared/navbar.shared.component.tsx
@@ -180,9 +180,11 @@ const NavbarSharedComponent: FC = () => {
           </div>
           {!isOpen && <LogoSharedComponent className='lg:hidden absolute' />}
           <MenuDesktopComponent data={data} loading={loading} />
+          {getENV(ENV.PUBLIC_LANG) === 'ON' && (
               <div className='py-1 lg:hidden'>
                 <LanguageSharedComponent className='border border-primary rounded-lg p-2 uppercase' />
               </div>
+          )}
         </div>
       </nav>
     </>


### PR DESCRIPTION
This pull request introduces a conditional display of the language selector in the navbar. The selector's visibility is determined by the `PUBLIC_LANG` environment variable, enhancing configurability and adapting its behavior based on the environment settings.